### PR TITLE
Use passed clientId instead of default constant value.

### DIFF
--- a/src/IdentityClient.cs
+++ b/src/IdentityClient.cs
@@ -45,6 +45,8 @@ namespace Vasont.IdentityServer.Backchannel
         /// </summary>
         private readonly string identityClientSecret;
 
+        private readonly string clientId;
+
         /// <summary>
         /// Contains the client authentication token response.
         /// </summary>
@@ -61,11 +63,12 @@ namespace Vasont.IdentityServer.Backchannel
         /// <param name="resourceUri">Contains the URI to the Identity API endpoint.</param>
         /// <param name="identityClientSecret">Contains the API resource client secret.</param>
         /// <param name="useDiscoveryForEndpoint">Contains a value indicating whether the discovery endpoint is used for token endpoint information.</param>
-        public IdentityClient(Uri authorityUri, Uri resourceUri, string identityClientSecret, bool useDiscoveryForEndpoint = true)
+        public IdentityClient(Uri authorityUri, Uri resourceUri, string identityClientSecret, string clientId, bool useDiscoveryForEndpoint = true)
         {
             this.AuthorityUri = authorityUri;
             this.ResourceUri = resourceUri;
             this.identityClientSecret = identityClientSecret;
+            this.clientId = String.IsNullOrEmpty(clientId) ? DefaultIdentityClientId : clientId;
             this.ErrorResponse = new IdentityErrorResponseModel();
             this.useDiscoveryForEndpoint = useDiscoveryForEndpoint;
         }
@@ -199,7 +202,7 @@ namespace Vasont.IdentityServer.Backchannel
                 tokenEndpointUrl = new Uri(this.AuthorityUri, "/connect/token").ToString();
             }
 
-            this.tokenResponse = await this.RequestClientCredentials(tokenEndpointUrl, DefaultIdentityClientId, scopes, cancellationToken).ConfigureAwait(false);
+            this.tokenResponse = await this.RequestClientCredentials(tokenEndpointUrl, this.clientId, scopes, cancellationToken).ConfigureAwait(false);
 
             // an error occurred...
             if (this.tokenResponse.IsError)
@@ -410,7 +413,7 @@ namespace Vasont.IdentityServer.Backchannel
             }
 
             request.Credentials = credentials;
-            request.UserAgent = DefaultIdentityClientId;
+            request.UserAgent = this.clientId;
             request.Accept = "application/json";
             request.ContentType = contentType;
 

--- a/src/IdentityClient.cs
+++ b/src/IdentityClient.cs
@@ -68,7 +68,7 @@ namespace Vasont.IdentityServer.Backchannel
             this.AuthorityUri = authorityUri;
             this.ResourceUri = resourceUri;
             this.identityClientSecret = identityClientSecret;
-            this.clientId = String.IsNullOrEmpty(clientId) ? DefaultIdentityClientId : clientId;
+            this.clientId = String.IsNullOrWhiteSpace(clientId) ? DefaultIdentityClientId : clientId;
             this.ErrorResponse = new IdentityErrorResponseModel();
             this.useDiscoveryForEndpoint = useDiscoveryForEndpoint;
         }

--- a/src/IdentityClient.cs
+++ b/src/IdentityClient.cs
@@ -45,6 +45,9 @@ namespace Vasont.IdentityServer.Backchannel
         /// </summary>
         private readonly string identityClientSecret;
 
+        /// <summary>
+        /// Contains the identity of the client
+        /// </summary>
         private readonly string clientId;
 
         /// <summary>
@@ -62,6 +65,7 @@ namespace Vasont.IdentityServer.Backchannel
         /// <param name="authorityUri">Contains the URI to the Identity Authority endpoint.</param>
         /// <param name="resourceUri">Contains the URI to the Identity API endpoint.</param>
         /// <param name="identityClientSecret">Contains the API resource client secret.</param>
+        /// <param name="clientId">Contains the identity of the client.</param>
         /// <param name="useDiscoveryForEndpoint">Contains a value indicating whether the discovery endpoint is used for token endpoint information.</param>
         public IdentityClient(Uri authorityUri, Uri resourceUri, string identityClientSecret, string clientId, bool useDiscoveryForEndpoint = true)
         {

--- a/src/Vasont.IdentityServer.Backchannel.csproj
+++ b/src/Vasont.IdentityServer.Backchannel.csproj
@@ -9,9 +9,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
-    <Version>1.1.2</Version>
+    <AssemblyVersion>1.1.3.0</AssemblyVersion>
+    <FileVersion>1.1.3.0</FileVersion>
+    <Version>1.1.3</Version>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReleaseNotes>updated code to support new identity model library.</PackageReleaseNotes>


### PR DESCRIPTION
Updating the client class to accept the clientId when passed, instead of always using the default constant.